### PR TITLE
Updates

### DIFF
--- a/scripts/esbuild.config.js
+++ b/scripts/esbuild.config.js
@@ -6,7 +6,16 @@ export const config = {
   format: 'esm',
   outfile: './dist/main.js',
   metafile: true,
-  external: ['react', 'react-dom/client', 'react-router', 't-a-i'],
+  minify: true,
+  jsx: 'automatic',
+  external: [
+    'prop-types',
+    'react',
+    'react/jsx-runtime',
+    'react-dom/client',
+    'react-router',
+    't-a-i'
+  ],
   plugins: [{
     name: 'copyFiles',
     setup (build) {

--- a/scripts/start-dev.js
+++ b/scripts/start-dev.js
@@ -4,6 +4,7 @@ import { config } from './esbuild.config.js'
 
 const context = await esbuild.context({
   ...config,
+  minify: false,
   define: {
     'window.__TAI_ENV__': JSON.stringify('development')
   }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -4,6 +4,7 @@ export const About = React.memo(() => {
   return (
     <>
       <h2>About this app</h2>
+      <p>Most of us have never watched a real live <a href='https://en.wikipedia.org/wiki/Leap_second'>leap second</a>.</p>
       <p>Under normal conditions, opportunities to see a leap second only occur once every 18 months or so. In recent times (as of 2026) there has been an extended dry spell of leap seconds; the most recent was on 31 December 2016. Furthermore, leap seconds <a href='https://en.wikipedia.org/wiki/Leap_second#Future'>may soon be abolished entirely</a>, which means there may <em>never</em> be another one.</p>
       <p>This app allows you to revisit past leap seconds. You can also visit a few other points of interest.</p>
       <p>Official sources are ambiguous and inconsistent about how the relationship between TAI and Unix time should be modelled during a leap second. This app provides <a href='https://github.com/qntm/t-a-i?tab=readme-ov-file#modelling-discontinuities'>several different options</a> for this. Try pausing during a leap second and switching between the models.</p>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -13,6 +13,9 @@ import { multiplyByScale } from '../utils.tsx'
 
 const ATOMIC_START = -283_996_798_577_182_000n
 
+// `null` on main page
+const getPageFromAddressBar = () => new URLSearchParams(location.search).get('page')
+
 export const App = React.memo(() => {
   const [isHidden, setIsHidden] = useState(document.hidden)
 
@@ -23,10 +26,9 @@ export const App = React.memo(() => {
     })
   }, [])
 
-  // `null` on main page
-  const [page, setPage] = useState(new URLSearchParams(location.search).get('page'))
+  const [page, setPage] = useState(getPageFromAddressBar)
 
-  const setPage2 = useCallback(page => {
+  const pushPage = useCallback(page => {
     const url = new URL(location)
     if (page === null) {
       url.searchParams.delete('page')
@@ -37,17 +39,28 @@ export const App = React.memo(() => {
     setPage(page)
   }, [])
 
+  // Handle case where used clicks "Back"
+  useEffect(() => {
+    const onPopstate = () => {
+      setPage(getPageFromAddressBar())
+    }
+    window.addEventListener('popstate', onPopstate)
+    return () => {
+      window.removeEventListener('popstate', onPopstate)
+    }
+  }, [setPage])
+
   const handleClickQm = useCallback(() => {
-    setPage2('about')
-  }, [setPage2])
+    pushPage('about')
+  }, [pushPage])
 
   const handleClickX = useCallback(() => {
-    setPage2(null)
-  }, [setPage2])
+    pushPage(null)
+  }, [pushPage])
 
   const handleClickMore = useCallback(() => {
-    setPage2('points')
-  }, [setPage2])
+    pushPage('points')
+  }, [pushPage])
 
   const [model, setModel] = useState(INITIAL_MODEL)
   const [precisionOption, setPrecisionOption] = useState(INITIAL_PRECISION_OPTION)
@@ -126,8 +139,8 @@ export const App = React.memo(() => {
     }
 
     goToAtomic(atomicNanos)
-    setPage2(null)
-  }, [converter, model, params, goToAtomic, setPage2])
+    pushPage(null)
+  }, [converter, model, params, goToAtomic, pushPage])
 
   return (
     <>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -84,7 +84,7 @@ export const Main = ({
 
   const handleClickBack = useCallback(() => {
     const now = BigInt(Date.now()) * 1_000_000n
-    const atomicNanos = multiplyByScale(now - 5_000_000_000n, params.scale) + params.offset
+    const atomicNanos = multiplyByScale(now - 10_000_000_000n, params.scale) + params.offset
     goToAtomic(atomicNanos)
   }, [params, goToAtomic])
 
@@ -189,6 +189,9 @@ export const Main = ({
             <button onClick={handleClickMostRecent}>
               most recent leap second
             </button>
+            <button onClick={handleClickBack}>
+              back a bit
+            </button>
             <button onClick={handleClickNow}>
               now
             </button>
@@ -249,10 +252,6 @@ export const Main = ({
       </div>
 
       <div className='buttons' style={{ justifyContent: 'center' }}>
-        <button className='secondary' onClick={handleClickBack}>
-          Back a bit
-        </button>
-
         {params.pausedAt === undefined && (
           <button className='secondary' onClick={handleClickPause}>
             Pause

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,9 @@
     <script type="importmap">
       {
         "imports": {
+          "prop-types": "https://esm.sh/prop-types@15",
           "react": "https://esm.sh/react@19",
+          "react/jsx-runtime": "https://esm.sh/react@19/jsx-runtime",
           "react-dom/": "https://esm.sh/react-dom@19/",
           "t-a-i/": "https://esm.sh/t-a-i@5/"
         }

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -199,6 +199,15 @@ export const POINTS_OF_INTEREST = [
   { unixMillis: Date.UTC(1996, JAN, 1), offsetChange: 1, description: 'Leap second' },
   { unixMillis: Date.UTC(1997, JUL, 1), offsetChange: 1, description: 'Leap second' },
   { unixMillis: Date.UTC(1999, JAN, 1), offsetChange: 1, description: 'Leap second' },
+  {
+    unixMillis: Date.UTC(2000, JAN, 1),
+    description: (
+      <>
+        New millennium.<br />
+        No change in parameters<br />
+      </>
+    )
+  },
   { unixMillis: Date.UTC(2006, JAN, 1), offsetChange: 1, description: 'Leap second' },
   { unixMillis: Date.UTC(2009, JAN, 1), offsetChange: 1, description: 'Leap second' },
   { unixMillis: Date.UTC(2012, JUL, 1), offsetChange: 1, description: 'Leap second' },


### PR DESCRIPTION
* `prop-types` is now an external.
* We now use the relatively new automatic React runtime everywhere - this affects our ESLint configuration, esbuild configuration, and unit testing module loading.
* We no longer minify our code in development.
* Fixed behaviour when navigating back from a sub-page to the main page.
* The "back a bit" button has been moved up to "Jump to..." and now goes back 10 realtime seconds, not 5.
* A new point of interest has been added for 1 January 2000.